### PR TITLE
Consistent .editorconfig indent size

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -5,7 +5,7 @@ charset = utf-8
 
 [*.js]
 indent_style = tab
-indent_size = 4
+indent_size = 2
 end_of_line = lf
 insert_final_newline = true
 trim_trailing_whitespace = true


### PR DESCRIPTION
Making .editorconfig consistent with .prettierrc and ESLint configs.

If the configurations are not consistent, editors and IDEs may show different indentation than GitHub, messing up JSDocs and Markdown documents.