### PR TITLE
allow loading media assets from node_modules

### DIFF
--- a/packages/react-union-scripts/scripts/webpack.config.js
+++ b/packages/react-union-scripts/scripts/webpack.config.js
@@ -89,7 +89,7 @@ const getCommonConfig = ({ outputMapper }) => ({
 			},
 			{
 				test: /\.(png|jpg|jpeg|gif|svg|woff|woff2)$/,
-				include: [resolveSymlink(process.cwd(), './src')],
+				include: [resolveSymlink(process.cwd(), './src'), resolveSymlink(process.cwd(), './node_modules')],
 				use: [
 					{
 						loader: require.resolve('url-loader'),


### PR DESCRIPTION
This is needed, when there is some dependency with (s)css files in the project, which have their own png/svg/... assets referenced from their stylesheets. Or is it solvable by another way?


