### PR TITLE
added missing dependency for eslint-config-prettier

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ build/
 # Visual Studio Code - https://code.visualstudio.com/
 .settings/
 .vscode/
+.history
 tsconfig.json
 jsconfig.json
 

--- a/boilerplates/react-union-boilerplate-basic/package.json
+++ b/boilerplates/react-union-boilerplate-basic/package.json
@@ -21,6 +21,7 @@
     "babel-preset-react": "6.23.0",
     "eslint": "4.7.2",
     "eslint-config-react-union": "^0.2.0",
+    "eslint-config-prettier": "^2.9.0",
     "eslint-plugin-babel": "4.1.2",
     "eslint-plugin-import": "2.7.0",
     "eslint-plugin-prettier": "2.6.0",

--- a/boilerplates/react-union-boilerplate-liferay-basic/package.json
+++ b/boilerplates/react-union-boilerplate-liferay-basic/package.json
@@ -22,6 +22,7 @@
     "babel-preset-react": "6.23.0",
     "eslint": "4.7.2",
     "eslint-config-react-union": "^0.2.0",
+    "eslint-config-prettier": "^2.9.0",
     "eslint-plugin-babel": "4.1.2",
     "eslint-plugin-import": "2.7.0",
     "eslint-plugin-prettier": "2.6.0",


### PR DESCRIPTION
I've added eslint-config-prettier to the boilerplates since it was failing on missing dependency.

eslint-config-prettier is defined as peer dependency in eslint-config-react-union