### PR TITLE
add other monorepo packages to the loaders

### DIFF
--- a/packages/react-union-scripts/scripts/lib/__tests__/fs-test.js
+++ b/packages/react-union-scripts/scripts/lib/__tests__/fs-test.js
@@ -142,4 +142,17 @@ describe('fs', () => {
 			]);
 		});
 	});
+	describe('readAllNonUnionPackages', () => {
+		it('should read all non union packages from workspace', () => {
+			createMockRootPkgJSON();
+			createMockGlob([
+				'package/union-app-test',
+				'package/union-app-test1',
+				'package/union-widget-test',
+				'package/custom-pkg',
+			]);
+			const utilsFs = require('../fs');
+			expect(utilsFs.readAllNonUnionPackages('union-app', 'union-widget')).toEqual(['custom-pkg']);
+		});
+	});
 });


### PR DESCRIPTION
closes #81 

I don't have any better solution for now. This solution will add everything other than widgets or apps to the loaders and resolve. We must trust the Webpack that he will remove potentially unused packages from our monorepo for a concrete app.