### PR TITLE
Add withWidgetContext HOC

### DIFF
--- a/packages/react-union/src/decorators/index.js
+++ b/packages/react-union/src/decorators/index.js
@@ -1,1 +1,2 @@
 export { default as withErrorBoundary } from './withErrorBoundary';
+export { default as withWidgetContext } from './withWidgetContext';

--- a/packages/react-union/src/decorators/withErrorBoundary/withErrorBoundary.js
+++ b/packages/react-union/src/decorators/withErrorBoundary/withErrorBoundary.js
@@ -2,12 +2,15 @@ import React, { Component } from 'react';
 import path from 'ramda/src/path';
 
 import { ConfigShape } from '../../shapes';
+import { getDisplayName } from '../../utils';
 
 const getName = path(['props', 'descriptor', 'name']);
 
-const withErrorBoundary = WrappedComponent => {
-	class UnionWidgetErrorBoundary extends Component {
+const withErrorBoundary = NextComponent => {
+	class WithErrorBoundary extends Component {
 		static propTypes = ConfigShape;
+
+		static displayName = `WithErrorBoundary(${getDisplayName(NextComponent)})`;
 
 		state = {
 			hasError: false,
@@ -25,11 +28,11 @@ const withErrorBoundary = WrappedComponent => {
 				return `An error has occurred in widget "${name}". See the console output for more details.`;
 			}
 
-			return <WrappedComponent {...this.props} />;
+			return <NextComponent {...this.props} />;
 		}
 	}
 
-	return UnionWidgetErrorBoundary;
+	return WithErrorBoundary;
 };
 
 export default withErrorBoundary;

--- a/packages/react-union/src/decorators/withWidgetContext/index.js
+++ b/packages/react-union/src/decorators/withWidgetContext/index.js
@@ -1,0 +1,1 @@
+export default from './withWidgetContext';

--- a/packages/react-union/src/decorators/withWidgetContext/withWidgetContext.js
+++ b/packages/react-union/src/decorators/withWidgetContext/withWidgetContext.js
@@ -1,0 +1,23 @@
+import React from 'react';
+
+import { WidgetContext } from '../../contexts';
+import { getDisplayName } from '../../utils';
+
+/**
+ * HOC which adds the `namespace` and `data` props to passed component.
+ *
+ * @param {React.Component} NextComponent component to bind the props to
+ */
+const withWidgetContext = NextComponent => {
+	const WithWidgetContext = props => (
+		<WidgetContext.Consumer>
+			{value => <NextComponent {...props} {...value} />}
+		</WidgetContext.Consumer>
+	);
+
+	WithWidgetContext.displayName = `WithWidgetContext(${getDisplayName(NextComponent)})`;
+
+	return WithWidgetContext;
+};
+
+export default withWidgetContext;

--- a/packages/react-union/src/index.js
+++ b/packages/react-union/src/index.js
@@ -1,4 +1,6 @@
 export * from './shapes';
 export * from './dom';
 export * from './contexts';
+
 export Union from './components/Union';
+export withWidgetContext from './decorators/withWidgetContext';

--- a/packages/react-union/src/utils.js
+++ b/packages/react-union/src/utils.js
@@ -42,3 +42,5 @@ export const createElementWithId = (id, parent, elementType = 'div') => {
 };
 
 export const noop = always(null);
+
+export const getDisplayName = Component => Component.displayName || Component.name || 'Component';


### PR DESCRIPTION
Quite often you need to use CMS data in e.g. lifecycle hooks or handler methods. A HOC makes it easier to wrap containers so that the necessary data is available (without needing to use a render prop in the parent component).