### PR TITLE
Use document instead of document.body as parent

### DIFF
--- a/packages/react-union/API.md
+++ b/packages/react-union/API.md
@@ -123,7 +123,7 @@ Renders your widgets based on provided _routes_ and the _widget descriptors_ in 
 * [`onScanEnd`]\(_function_) - Called after the scan of the HTML is done.
 * [`onScanError`]\(_function_) - Called when there is an error while scanning the HTML.
 * [`onScanStart`]\(_function_) - Called before the scan of the HTML.
-* [`parent`]\(_DOM element_) - Element in which the scan is running. The default value is `document.body`.
+* [`parent`]\(_DOM element_) - Element in which the scan is running. The default value is `document`.
 * [`routes`]\(_array of Route_) - Array of routes that are supported by your application. See section _Route_.
 * [`strictMode`]\(_boolean_) - Enable React.Strict mode. By default `true`.
 

--- a/packages/react-union/src/components/Union/Union.js
+++ b/packages/react-union/src/components/Union/Union.js
@@ -31,7 +31,7 @@ class Union extends Component {
 		 */
 		onScanStart: PropTypes.func,
 		/**
-		 * Element in which the scan is running. By default `document.body`.
+		 * Element in which the scan is running. By default `document`.
 		 */
 		parent: PropTypes.object,
 		/**
@@ -71,7 +71,7 @@ class Union extends Component {
 
 		onScanStart();
 
-		const domParent = parent || document.body;
+		const domParent = parent || document;
 
 		scan(routes, domParent).then(
 			result => {


### PR DESCRIPTION
We should be able to place the common descriptor in `<head>` as well. Using just `document.body` will lead to hard-to-find bugs.