### PR TITLE
Change devtools in client webpack configs

### DIFF
--- a/packages/react-union-scripts/scripts/lib/utils.js
+++ b/packages/react-union-scripts/scripts/lib/utils.js
@@ -62,7 +62,7 @@ const DEFAULT_UNION_CONFIG = {
 		widgetPattern: DEFAULT_WIDGET_PATTERN,
 		appPattern: DEFAULT_APP_PATTERN,
 	},
-	sourceMaps: false,
+	sourceMaps: 'nosources',
 	uglifyOptions: {
 		parallel: true,
 		cache: true,

--- a/packages/react-union-scripts/scripts/webpack.config.js
+++ b/packages/react-union-scripts/scripts/webpack.config.js
@@ -1,6 +1,7 @@
 const invariant = require('invariant');
 const merge = require('webpack-merge');
 const path = require('path');
+const { cond, identity, equals, always, T } = require('ramda');
 
 const cli = require('./lib/cli');
 const { getUnionConfig, getAppConfig, mergeWhen, getForMode } = require('./lib/utils');
@@ -130,7 +131,7 @@ const getWebpackConfig_ = (config, isServerConfig) => {
 			loaderOptionsPlugin(true),
 			mergeWhen(generateTemplate, htmlPlugin, config, outputPath),
 			{
-				devtool: 'cheap-source-map',
+				devtool: 'cheap-module-eval-source-map',
 			}
 		);
 
@@ -139,7 +140,12 @@ const getWebpackConfig_ = (config, isServerConfig) => {
 			clientConfig(),
 			{
 				bail: true,
-				devtool: sourceMaps ? 'source-map' : false,
+				devtool: cond([
+					[equals(true), always('source-map')],
+					[equals('hidden'), always('hidden-source-map')],
+					[equals('nosources'), always('nosources-source-map')],
+					[T, identity],
+				])(sourceMaps),
 			},
 			uglifyJSPlugin(cli.verbose, config)
 		);

--- a/packages/react-union-scripts/scripts/webpack/plugins.parts.js
+++ b/packages/react-union-scripts/scripts/webpack/plugins.parts.js
@@ -56,7 +56,7 @@ const uglifyJSPlugin = (verbose, { sourceMaps, uglifyOptions: { cache, parallel,
 			new UglifyWebpackPlugin({
 				cache,
 				parallel,
-				sourceMap: sourceMaps,
+				sourceMap: Boolean(sourceMaps),
 				uglifyOptions: {
 					mangle,
 					warnings: verbose,


### PR DESCRIPTION
`cheap-module-eval-source-map` is outright better for development than the current devtool.

I think that `nosources` is probably the best production default (filenames in stacktraces, but no sourcecode is contained)