### PR TITLE
Webpack fix for weidgets using appolo client

### DIFF
--- a/packages/react-union-scripts/scripts/webpack/common.parts.js
+++ b/packages/react-union-scripts/scripts/webpack/common.parts.js
@@ -29,7 +29,7 @@ const optimization = () => ({
 const resolve = modules => ({
 	resolve: {
 		modules,
-		extensions: ['.webpack.js', '.web.js', '.js', '.json'],
+		extensions: ['.webpack.js', '.web.js', '.mjs', '.js', '.json'],
 	},
 });
 


### PR DESCRIPTION
I was trying to use GQL Apollo client with the widgets but had problems with the build. This fixed it.