### PR TITLE
Remove old widget entry points

### DIFF
--- a/boilerplates/react-union-boilerplate-basic/src/widgets/Content/content.widget.js
+++ b/boilerplates/react-union-boilerplate-basic/src/widgets/Content/content.widget.js
@@ -1,1 +1,0 @@
-export default from './components/Root';

--- a/boilerplates/react-union-boilerplate-basic/src/widgets/Hero/hero.widget.js
+++ b/boilerplates/react-union-boilerplate-basic/src/widgets/Hero/hero.widget.js
@@ -1,1 +1,0 @@
-export default from './components/Root';


### PR DESCRIPTION
We use index.js now, don't know why these files are still there