### PR TITLE
add: arrow-body-style & curly eslint rules

### DIFF
--- a/packages/eslint-config-react-union/rules/base.js
+++ b/packages/eslint-config-react-union/rules/base.js
@@ -18,6 +18,7 @@ module.exports = {
 	rules: {
 		'array-bracket-spacing': ['error', 'never'],
 		'array-callback-return': 'error',
+		'arrow-body-style': ['error', 'as-needed'],
 		'arrow-spacing': 'error',
 		'arrow-parens': 'off',
 		'babel/new-cap': 'error',
@@ -35,6 +36,7 @@ module.exports = {
 		'computed-property-spacing': ['error', 'never'],
 		'consistent-this': ['error', 'self'],
 		'consistent-return': 'off',
+		curly: 'error',
 		'dot-notation': 'error',
 		'dot-location': ['error', 'property'],
 		eqeqeq: ['error', 'smart'],

--- a/packages/react-union-scripts/scripts/webpack/loaders.parts.js
+++ b/packages/react-union-scripts/scripts/webpack/loaders.parts.js
@@ -34,7 +34,7 @@ const loadCSS = isServerConfig => ({
 						options: {
 							modules: {
 								localIdentName: '[name]__[local]--[hash:base64:5]',
-												},
+							},
 							onlyLocals: isServerConfig,
 						},
 					},


### PR DESCRIPTION
Issue #445 

I've added `arrow-body-style` & `curly` eslint rules, but `padding-line-between-statements` needs some more project specific rules. Could you please define where should be added new lines?
